### PR TITLE
Attempt at fixing it for Sierra

### DIFF
--- a/aircontrol
+++ b/aircontrol
@@ -7,8 +7,8 @@ else
 fi
 
 read -d '' APPLESCRIPT <<EOF
-set _isElCapitanOrBetter to (system attribute "sys1") ≥ 10 and (system attribute "sys2") ≥ 11
-if _isElCapitanOrBetter then
+set _isElCapitan to (system attribute "sys1") ≥ 10 and (system attribute "sys2") = 11
+if _isElCapitan then
     tell application "System Events"
         tell process "SystemUIServer"
             tell (menu bar item 1 of menu bar 1 whose description contains "Displays Menu")

--- a/aircontrol
+++ b/aircontrol
@@ -7,10 +7,12 @@ else
 fi
 
 read -d '' APPLESCRIPT <<EOF
-set _isElCapitan to (system attribute "sys1") ≥ 10 and (system attribute "sys2") = 11
-if _isElCapitan then
-    tell application "System Events"
-        tell process "SystemUIServer"
+set _isElCapitan to (system attribute "sys1") = 10 and (system attribute "sys2") = 11
+set _isSierra to (system attribute "sys1") = 10 and (system attribute "sys2") = 12
+
+tell application "System Events"
+    tell process "SystemUIServer"
+        if _isElCapitan then
             tell (menu bar item 1 of menu bar 1 whose description contains "Displays Menu")
                 select
                     delay 0.1
@@ -18,16 +20,28 @@ if _isElCapitan then
                     delay 0.1
                     click menu item $tvname of menu 1
             end tell
-        end tell
-    end tell
-else
-    tell application "System Events"
-        tell process "SystemUIServer"
+        else if _isSierra then
+            if $tvname = 2 then
+                set tvname to "Turn AirPlay Off"
+            else
+                set tvname to $tvname
+            end if
+            click (menu bar item 1 of menu bar 1 whose description contains "Displays")
+            set mymenu to result
+            delay 0.5
+            repeat with myitem in (menu items of menu of mymenu)
+                set myname to name of myitem
+                if myname = tvname then
+                    click myitem
+                    exit
+                end if
+            end repeat
+        else
             click (menu bar item 1 of menu bar 1 whose description contains "Displays")
             click menu item $tvname of menu 1 of result
-        end tell
+        end if
     end tell
-end if
+end tell
 EOF
 
 osascript -e "$APPLESCRIPT" > /dev/null


### PR DESCRIPTION
I tried the original code on a Sierra machine and was able to open the menu.

Unfortunately, I didn't have any AppleTV on the network to try it out fully but
the basic AppleScript seems valid. (I tried with "Open Displays Preferences…")

Opening that up to see if it can solve #3.